### PR TITLE
Transparently proxy root URLSs

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,9 @@
   command = "npm run build"
   functions = "./dist/functions"
 
+# Netlify's functions are invoked at `/.netlify/functions/fn-name`, which is 
+# definitely not ideal, and we'd like to also hide the provider (netlify) in the
+# url. This adds a 200 proxy from `/fn-name` to `/.netlify/functions/fn-name` 
 [[redirects]]
   from = "/win"
   to = "/.netlify/functions/win-install"
@@ -12,8 +15,7 @@
   # Always redirect, even if somehow some content exists at the root "from"
   force = true
 
-  headers = {X-From = "Netlify"}
-
+  headers = {Apollo-Proxy-Rule = "from-root-config"}
 
 [[redirects]]
   from = "/nix"
@@ -25,4 +27,4 @@
   # Always redirect, even if somehow some content exists at the root "from"
   force = true
 
-  headers = {X-From = "Netlify"}
+  headers = {Apollo-Proxy-Rule = "from-root-config"}

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,28 @@
 [build]
   command = "npm run build"
   functions = "./dist/functions"
+
+[[redirects]]
+  from = "/win"
+  to = "/.netlify/functions/win-install"
+
+  # Proxy / rewrite transparently without the `location` hop.
+  status = 200
+
+  # Always redirect, even if somehow some content exists at the root "from"
+  force = true
+
+  headers = {X-From = "Netlify"}
+
+
+[[redirects]]
+  from = "/nix"
+  to = "/.netlify/functions/nix-install"
+
+  # Proxy / rewrite transparently without the `location` hop.
+  status = 200
+
+  # Always redirect, even if somehow some content exists at the root "from"
+  force = true
+
+  headers = {X-From = "Netlify"}


### PR DESCRIPTION
Netlify's functions are invoked at `/.netlify/functions/fn-name`, which is definitely not ideal, and we'd like to also hide the provider (netlify) in the url.

This PR adds a 200 proxy from `/nix` to `/.netlify/functions/nix-installer` and same for windows 