### PR TITLE
Added legacy cli handler

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -42,7 +42,7 @@
   headers = {Apollo-Proxy-Rule = "from-root-config"}
 
 [[redirects]]
-  from = "/legacy-cli/:platform/:version"
+  from = "/legacy-cli/*"
   to = "/.netlify/functions/legacy-cli"
 
   # Proxy / rewrite transparently without the `location` hop.

--- a/netlify.toml
+++ b/netlify.toml
@@ -40,3 +40,15 @@
   force = true
 
   headers = {Apollo-Proxy-Rule = "from-root-config"}
+
+[[redirects]]
+  from = "/legacy-cli/:platform/:version"
+  to = "/.netlify/functions/legacy-cli"
+
+  # Proxy / rewrite transparently without the `location` hop.
+  status = 200
+
+  # Always redirect, even if somehow some content exists at the root "from"
+  force = true
+
+  headers = {Apollo-Proxy-Rule = "from-root-config"}

--- a/src/functions/legacy-cli/legacy-cli.ts
+++ b/src/functions/legacy-cli/legacy-cli.ts
@@ -1,0 +1,71 @@
+import {
+  Handler,
+  APIGatewayProxyResult,
+  APIGatewayProxyEvent,
+} from 'aws-lambda';
+// import btoa from 'btoa';
+import { getFetcher } from '../../lib/getFetcher';
+import { track } from '../../lib/segment';
+import { initSentry, sentryWrapHandler } from '../../lib/sentry';
+
+initSentry();
+
+const GITHUB_RELEASE =
+  'https://github.com/apollographql/apollo-tooling/releases';
+
+const handler: Handler<APIGatewayProxyEvent, APIGatewayProxyResult> = async (
+  event,
+  _context,
+) => {
+  const fetch = getFetcher();
+
+  // silence unused variable warning
+  // @ts-ignore: TS6133
+  const [_, __, platform, version] = event.path.split('/');
+
+  // we don't need to check and see if platform and version both exist.
+  // The redirect rules should ensure that there's always SOMETHING for those
+  // values, otherwise the route will 404 and not reach here
+
+  // this only supports 64 bit architectures. I don't see us changing this but if we do, this will become gross
+  const downloadUrl = `${GITHUB_RELEASE}/download/apollo@${version}/apollo-v${version}-darwin-x64.tar.gz`;
+
+  // we just want to make sure it's a valid download so we just need to HEAD
+  const response = await fetch(downloadUrl, {
+    method: 'HEAD',
+  });
+
+  if (response.ok) {
+    track({
+      event: 'Legacy CLI download',
+      context: {
+        app: 'Apollo iOS',
+        os: 'darwin',
+      },
+      properties: {
+        release_version: version,
+      },
+    });
+
+    return {
+      statusCode: 301,
+      headers: {
+        Location: downloadUrl,
+      },
+      body: `Redirecting to ${downloadUrl}`,
+    };
+  }
+
+  if (response.status === 404) {
+    return {
+      statusCode: 400,
+      body: `Couldn't find release for version ${version} on ${platform} on GitHub Releases. This could be a problem with GitHub being offline or missing this version`,
+    };
+  }
+  return {
+    statusCode: 500,
+    body: `Error when loading the legacy CLI for ${version} on ${platform} on GitHub releases. This could be because GitHub is down. The error we received from GitHub was ${response.statusText}`,
+  };
+};
+
+module.exports.handler = sentryWrapHandler(handler);

--- a/src/functions/legacy-cli/legacy-cli.ts
+++ b/src/functions/legacy-cli/legacy-cli.ts
@@ -3,7 +3,6 @@ import {
   APIGatewayProxyResult,
   APIGatewayProxyEvent,
 } from 'aws-lambda';
-// import btoa from 'btoa';
 import { getFetcher } from '../../lib/getFetcher';
 import { track } from '../../lib/segment';
 import { initSentry, sentryWrapHandler } from '../../lib/sentry';

--- a/src/functions/legacy-cli/legacy-cli.ts
+++ b/src/functions/legacy-cli/legacy-cli.ts
@@ -23,9 +23,15 @@ const handler: Handler<APIGatewayProxyEvent, APIGatewayProxyResult> = async (
   // @ts-ignore: TS6133
   const [_, __, platform, version] = event.path.split('/');
 
-  // we don't need to check and see if platform and version both exist.
-  // The redirect rules should ensure that there's always SOMETHING for those
-  // values, otherwise the route will 404 and not reach here
+  // rather than 404 with `undefined` as versions later, we can check and fail early here
+  if (!platform || !version) {
+    return {
+      statusCode: 400,
+      body: `Missing ${
+        !platform ? 'platform and ' : ''
+      }version in URL path. Check your URL and try again. Correct format: "/legacy-cli/darwin/2.x.x"`,
+    };
+  }
 
   // this only supports 64 bit architectures. I don't see us changing this but if we do, this will become gross
   const downloadUrl = `${GITHUB_RELEASE}/download/apollo@${version}/apollo-v${version}-darwin-x64.tar.gz`;


### PR DESCRIPTION
Add a handler for downloading the legacy cli. The redirect rules for this look a little different, since the downloader expects `legacy-cli/platform/version` right now, and we don't want to break that. There's probably more concise way to do this redirect, but I don't have time this afternoon to look at it. 

This should preserve the exact same segment reporting that was supported previously, and do a 301 redirect, just like we were doing, for the actual download 