### PR TITLE
Redirect the root domain to the documentation

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -52,3 +52,9 @@
   force = true
 
   headers = {Apollo-Proxy-Rule = "from-root-config"}
+  
+[[redirects]]
+  from = "/"
+  to = "https://www.apollographql.com/docs/rover"
+
+  status = 302


### PR DESCRIPTION
Rather than serving up a 404 page on `rover.apollo.dev`, it seems like the documentation might be a good destination to send users.