### PR TITLE
feat: adds /quickstart/graphql for introspection

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -58,3 +58,33 @@
   to = "https://www.apollographql.com/docs/rover"
 
   status = 302
+
+[[redirects]]
+  from = "/quickstart"
+  to = "https://www.apollographql.com/docs/federation/quickstart"
+
+  headers = {Apollo-Proxy-Rule = "from-root-config"}
+
+[[redirects]]
+  from = "/quickstart/products/graphql"
+  to = "https://7bssbnldib.execute-api.us-east-1.amazonaws.com/Prod/graphql"
+
+  # Proxy / rewrite transparently without the `location` hop.
+  status = 200
+
+  # Always redirect, even if somehow some content exists at the root "from"
+  force = true
+
+  headers = {Apollo-Proxy-Rule = "from-root-config"}
+
+[[redirects]]
+  from = "/quickstart/reviews/graphql"
+  to = "https://w0jtezo2pa.execute-api.us-east-1.amazonaws.com/Prod/graphql"
+
+  # Proxy / rewrite transparently without the `location` hop.
+  status = 200
+
+  # Always redirect, even if somehow some content exists at the root "from"
+  force = true
+
+  headers = {Apollo-Proxy-Rule = "from-root-config"}


### PR DESCRIPTION
This endpoint will be used in place of the long aws link we currently have in the federation quickstart docs [here](https://www.apollographql.com/docs/federation/quickstart/#fetching-subgraph-schemas)