### PR TITLE
chore: makes remote_url_hash nullable

### DIFF
--- a/src/functions/telemetry/telemetry.ts
+++ b/src/functions/telemetry/telemetry.ts
@@ -39,7 +39,7 @@ interface Session {
   // the sha-256 hash of the current working directory
   cwd_hash: string;
   // the sha-256 hash of the git remote URL
-  remote_url_hash: string;
+  remote_url_hash: string | null;
   // Information about the current architecture/platform
   platform: Platform;
   // The current version of the CLI

--- a/src/lib/operations/track.mutation.graphql
+++ b/src/lib/operations/track.mutation.graphql
@@ -3,7 +3,7 @@ mutation RoverTrack(
   $command: String!
   $cwdHash: SHA256!
   $os: String!
-  $remoteUrlHash: SHA256!
+  $remoteUrlHash: SHA256
   $sessionId: ID!
   $version: String!
   $arguments: [RoverArgumentInput!]!


### PR DESCRIPTION
we're getting these errors in our telemetry handler:

```
Mar 31, 12:01:45 PM: 6f91b825 ERROR  Unhandled Promise Rejection 	{"errorType":"Runtime.UnhandledPromiseRejection","errorMessage":"Error: Variable \"$remoteUrlHash\" of non-null type \"SHA256!\" must not be null.: {\"response\":{\"errors\":[{\"message\":\"Variable \\\"$remoteUrlHash\\\" of non-null type \\\"SHA256!\\\" must not be null.\",\"locations\":[{\"line\":1,\"column\":92}],\"extensions\":{\"code\":\"BAD_USER_INPUT\"}}],\"status\":400,\"headers\":{}},\"request\":{\"query\":\"mutation RoverTrack($anonymousId: ID!, $command: String!, $cwdHash: SHA256!, $os: String!, $remoteUrlHash: SHA256!, $sessionId: ID!, $version: String!, $arguments: [RoverArgumentInput!]!, $ci: String) {\\n  trackRoverSession(\\n    anonymousId: $anonymousId\\n    command: $command\\n    cwdHash: $cwdHash\\n    os: $os\\n    remoteUrlHash: $remoteUrlHash\\n    sessionId: $sessionId\\n    version: $version\\n    arguments: $arguments\\n    ci: $ci\\n  )\\n}\\n\",\"variables\":{\"anonymousId\":\"0a08569b-28b6-4cfe-a464-4c23d44444cc\",\"command\":\"subgraph introspect\",\"cwdHash\":\"c52ddf65534b7b46035084358ab7902be4bfef220bdb503ac7039cc861905b05\",\"os\":\"linux\",\"remoteUrlHash\":null,\"sessionId\":\"a8f37dd2-cc97-49c1-b6d9-f38fadbc3c82\",\"version\":\"0.4.1\",\"arguments\":[],\"ci\":null}}}","reason":{"errorType":"Error","errorMessage":"Variable \"$remoteUrlHash\" of non-null type \"SHA256!\" must not be null.: {\"response\":{\"errors\":[{\"message\":\"Variable \\\"$remoteUrlHash\\\" of non-null type \\\"SHA256!\\\" must not be null.\",\"locations\":[{\"line\":1,\"column\":92}],\"extensions\":{\"code\":\"BAD_USER_INPUT\"}}],\"status\":400,\"headers\":{}},\"request\":{\"query\":\"mutation RoverTrack($anonymousId: ID!, $command: String!, $cwdHash: SHA256!, $os: String!, $remoteUrlHash: SHA256!, $sessionId: ID!, $version: String!, $arguments: [RoverArgumentInput!]!, $ci: String) {\\n  trackRoverSession(\\n    anonymousId: $anonymousId\\n    command: $command\\n    cwdHash: $cwdHash\\n    os: $os\\n    remoteUrlHash: $remoteUrlHash\\n    sessionId: $sessionId\\n    version: $version\\n    arguments: $arguments\\n    ci: $ci\\n  )\\n}\\n\",\"variables\":{\"anonymousId\":\"0a08569b-28b6-4cfe-a464-4c23d44444cc\",\"command\":\"subgraph introspect\",\"cwdHash\":\"c52ddf65534b7b46035084358ab7902be4bfef220bdb503ac7039cc861905b05\",\"os\":\"linux\",\"remoteUrlHash\":null,\"sessionId\":\"a8f37dd2-cc97-49c1-b6d9-f38fadbc3c82\",\"version\":\"0.4.1\",\"arguments\":[],\"ci\":null}}}","response":{"errors":[{"message":"Variable \"$remoteUrlHash\" of non-null type \"SHA256!\" must not be null.","locations":[{"line":1,"column":92}],"extensions":{"code":"BAD_USER_INPUT"}}],"status":400,"headers":{}},"request":{"query":"mutation RoverTrack($anonymousId: ID!, $command: String!, $cwdHash: SHA256!, $os: String!, $remoteUrlHash: SHA256!, $sessionId: ID!, $version: String!, $arguments: [RoverArgumentInput!]!, $ci: String) {\n  trackRoverSession(\n    anonymousId: $anonymousId\n    command: $command\n    cwdHash: $cwdHash\n    os: $os\n    remoteUrlHash: $remoteUrlHash\n    sessionId: $sessionId\n    version: $version\n    arguments: $arguments\n    ci: $ci\n  )\n}\n","variables":{"anonymousId":"0a08569b-28b6-4cfe-a464-4c23d44444cc","command":"subgraph introspect","cwdHash":"c52ddf65534b7b46035084358ab7902be4bfef220bdb503ac7039cc861905b05","os":"linux","remoteUrlHash":null,"sessionId":"a8f37dd2-cc97-49c1-b6d9-f38fadbc3c82","version":"0.4.1","arguments":[],"ci":null}},"stack":["Error: Variable \"$remoteUrlHash\" of non-null type \"SHA256!\" must not be null.: {\"response\":{\"errors\":[{\"message\":\"Variable \\\"$remoteUrlHash\\\" of non-null type \\\"SHA256!\\\" must not be null.\",\"locations\":[{\"line\":1,\"column\":92}],\"extensions\":{\"code\":\"BAD_USER_INPUT\"}}],\"status\":400,\"headers\":{}},\"request\":{\"query\":\"mutation RoverTrack($anonymousId: ID!, $command: String!, $cwdHash: SHA256!, $os: String!, $remoteUrlHash: SHA256!, $sessionId: ID!, $version: String!, $arguments: [RoverArgumentInput!]!, $ci: String) {\\n  trackRoverSession(\\n    anonymousId: $anonymousId\\n    command: $command\\n    cwdHash: $cwdHash\\n    os: $os\\n    remoteUrlHash: $remoteUrlHash\\n    sessionId: $sessionId\\n    version: $version\\n    arguments: $arguments\\n    ci: $ci\\n  )\\n}\\n\",\"variables\":{\"anonymousId\":\"0a08569b-28b6-4cfe-a464-4c23d44444cc\",\"command\":\"subgraph introspect\",\"cwdHash\":\"c52ddf65534b7b46035084358ab7902be4bfef220bdb503ac7039cc861905b05\",\"os\":\"linux\",\"remoteUrlHash\":null,\"sessionId\":\"a8f37dd2-cc97-49c1-b6d9-f38fadbc3c82\",\"version\":\"0.4.1\",\"arguments\":[],\"ci\":null}}}","    at /var/task/node_modules/graphql-request/dist/index.js:356:31","    at step (/var/task/node_modules/graphql-request/dist/index.js:63:23)","    at Object.next (/var/task/node_modules/graphql-request/dist/index.js:44:53)","    at fulfilled (/var/task/node_modules/graphql-request/dist/index.js:35:58)","    at processTicksAndRejections (internal/process/task_queues.js:95:5)"]},"promise":{},"stack":["Runtime.UnhandledPromiseRejection: Error: Variable \"$remoteUrlHash\" of non-null type \"SHA256!\" must not be null.: {\"response\":{\"errors\":[{\"message\":\"Variable \\\"$remoteUrlHash\\\" of non-null type \\\"SHA256!\\\" must not be null.\",\"locations\":[{\"line\":1,\"column\":92}],\"extensions\":{\"code\":\"BAD_USER_INPUT\"}}],\"status\":400,\"headers\":{}},\"request\":{\"query\":\"mutation RoverTrack($anonymousId: ID!, $command: String!, $cwdHash: SHA256!, $os: String!, $remoteUrlHash: SHA256!, $sessionId: ID!, $version: String!, $arguments: [RoverArgumentInput!]!, $ci: String) {\\n  trackRoverSession(\\n    anonymousId: $anonymousId\\n    command: $command\\n    cwdHash: $cwdHash\\n    os: $os\\n    remoteUrlHash: $remoteUrlHash\\n    sessionId: $sessionId\\n    version: $version\\n    arguments: $arguments\\n    ci: $ci\\n  )\\n}\\n\",\"variables\":{\"anonymousId\":\"0a08569b-28b6-4cfe-a464-4c23d44444cc\",\"command\":\"subgraph introspect\",\"cwdHash\":\"c52ddf65534b7b46035084358ab7902be4bfef220bdb503ac7039cc861905b05\",\"os\":\"linux\",\"remoteUrlHash\":null,\"sessionId\":\"a8f37dd2-cc97-49c1-b6d9-f38fadbc3c82\",\"version\":\"0.4.1\",\"arguments\":[],\"ci\":null}}}","    at process.<anonymous> (/var/runtime/index.js:35:15)","    at process.emit (events.js:412:35)","    at process.emit (domain.js:475:12)","    at processPromiseRejections (internal/process/promises.js:245:33)","    at processTicksAndRejections (internal/process/task_queues.js:96:32)"]}
```