### PR TITLE
fix: allow nullable remoteUrlHash

### DIFF
--- a/src/functions/telemetry/telemetry.ts
+++ b/src/functions/telemetry/telemetry.ts
@@ -39,7 +39,7 @@ interface Session {
   // the sha-256 hash of the current working directory
   cwd_hash: string;
   // the sha-256 hash of the git remote URL
-  remote_url_hash: string;
+  remote_url_hash: string | null;
   // Information about the current architecture/platform
   platform: Platform;
   // The current version of the CLI

--- a/src/generated/studio.ts
+++ b/src/generated/studio.ts
@@ -8409,7 +8409,7 @@ export type ZendeskTicketInput = {
 
 
 export const RoverTrack = gql`
-    mutation RoverTrack($anonymousId: ID!, $command: String!, $cwdHash: SHA256!, $os: String!, $remoteUrlHash: SHA256!, $sessionId: ID!, $version: String!, $arguments: [RoverArgumentInput!]!, $ci: String) {
+    mutation RoverTrack($anonymousId: ID!, $command: String!, $cwdHash: SHA256!, $os: String!, $remoteUrlHash: SHA256, $sessionId: ID!, $version: String!, $arguments: [RoverArgumentInput!]!, $ci: String) {
   trackRoverSession(
     anonymousId: $anonymousId
     command: $command
@@ -8428,7 +8428,7 @@ export type RoverTrackMutationVariables = Exact<{
   command: Scalars['String'];
   cwdHash: Scalars['SHA256'];
   os: Scalars['String'];
-  remoteUrlHash: Scalars['SHA256'];
+  remoteUrlHash?: InputMaybe<Scalars['SHA256']>;
   sessionId: Scalars['ID'];
   version: Scalars['String'];
   arguments: Array<RoverArgumentInput> | RoverArgumentInput;
@@ -8440,7 +8440,7 @@ export type RoverTrackMutation = { __typename?: 'Mutation', trackRoverSession?: 
 
 
 export const RoverTrackDocument = gql`
-    mutation RoverTrack($anonymousId: ID!, $command: String!, $cwdHash: SHA256!, $os: String!, $remoteUrlHash: SHA256!, $sessionId: ID!, $version: String!, $arguments: [RoverArgumentInput!]!, $ci: String) {
+    mutation RoverTrack($anonymousId: ID!, $command: String!, $cwdHash: SHA256!, $os: String!, $remoteUrlHash: SHA256, $sessionId: ID!, $version: String!, $arguments: [RoverArgumentInput!]!, $ci: String) {
   trackRoverSession(
     anonymousId: $anonymousId
     command: $command

--- a/src/lib/operations/track.mutation.graphql
+++ b/src/lib/operations/track.mutation.graphql
@@ -3,7 +3,7 @@ mutation RoverTrack(
   $command: String!
   $cwdHash: SHA256!
   $os: String!
-  $remoteUrlHash: SHA256!
+  $remoteUrlHash: SHA256
   $sessionId: ID!
   $version: String!
   $arguments: [RoverArgumentInput!]!


### PR DESCRIPTION
this update includes a fix for the `telemetry` endpoint that allows `remoteUrlHash` to be `null`.