### PR TITLE
💅 Re-prettier everything since the Prettier integration was malfunctioning

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Once upon many times that prettier has destructively reformatted code
+b1b98a30b12f45f44f3de7f4e4c59e4d17f0c98d

--- a/src/functions/download-router/download-router.ts
+++ b/src/functions/download-router/download-router.ts
@@ -13,8 +13,7 @@ const handler: Handler<APIGatewayProxyEvent, APIGatewayProxyResult> = async (
 ) => {
   try {
     // router.apollo.dev / download / nix / latest
-    let [_, __, inputPlatform, inputVersion] =
-      event.path.split("/");
+    let [_, __, inputPlatform, inputVersion] = event.path.split("/");
     return downloadEvent("router", inputPlatform, inputVersion, "installer");
   } catch (e) {
     return {

--- a/src/functions/telemetry/router.ts
+++ b/src/functions/telemetry/router.ts
@@ -1,35 +1,34 @@
-import {
-  APIGatewayProxyResult,
-  APIGatewayProxyEvent,
-} from "aws-lambda";
-import {track} from "../../lib/track";
+import { APIGatewayProxyResult, APIGatewayProxyEvent } from "aws-lambda";
+import { track } from "../../lib/track";
 import {
   RouterTrackDocument,
   RouterTrackMutationVariables,
   RouterUsageInput,
 } from "../../generated/studio";
-import {MALFORMED_REQUEST, Platform} from "./telemetry";
+import { MALFORMED_REQUEST, Platform } from "./telemetry";
 
 export const ROUTER_AGENT: string = "router";
 
 interface Request {
   // A random ID that is generated on first startup of the Router. It is not persistent between restarts of the Router, but will be persistent for hot reloads
-  session_id: string
+  session_id: string;
   // The version of the Router
-  version: string
+  version: string;
   // Information about the current architecture/platform
   platform: Platform;
   // Information about what was being used
   usage: object;
 }
 
-export async function routerHandler(event: APIGatewayProxyEvent, userAgent: string) : Promise<APIGatewayProxyResult> {
+export async function routerHandler(
+  event: APIGatewayProxyEvent,
+  userAgent: string
+): Promise<APIGatewayProxyResult> {
   // Make sure the body exists and contains the right keys to properly build
   // a Session
   if (!event.body) return MALFORMED_REQUEST;
   const request: Request = JSON.parse(event.body);
-  if (!request || !request.platform || !request.usage)
-    return MALFORMED_REQUEST;
+  if (!request || !request.platform || !request.usage) return MALFORMED_REQUEST;
 
   // we intentionally don't `await` this fn, because we don't want to block
   trackRouter(request, userAgent);

--- a/src/functions/telemetry/rover.ts
+++ b/src/functions/telemetry/rover.ts
@@ -1,13 +1,11 @@
-import {
-  APIGatewayProxyResult,
-  APIGatewayProxyEvent,
-} from "aws-lambda";
+import { APIGatewayProxyResult, APIGatewayProxyEvent } from "aws-lambda";
 import { track } from "../../lib/track";
 import {
   RoverTrackMutationVariables,
-  RoverArgumentInput, RoverTrackDocument,
+  RoverArgumentInput,
+  RoverTrackDocument,
 } from "../../generated/studio";
-import {MALFORMED_REQUEST, Platform} from "./telemetry";
+import { MALFORMED_REQUEST, Platform } from "./telemetry";
 
 export const ROVER_AGENT: string = "rover";
 
@@ -36,7 +34,10 @@ interface Session {
   cli_version: string;
 }
 
-export async function roverHandler(event: APIGatewayProxyEvent, userAgent: string) : Promise<APIGatewayProxyResult> {
+export async function roverHandler(
+  event: APIGatewayProxyEvent,
+  userAgent: string
+): Promise<APIGatewayProxyResult> {
   // Make sure the body exists and contains the right keys to properly build
   // a Session
   if (!event.body) return MALFORMED_REQUEST;

--- a/src/functions/telemetry/telemetry.ts
+++ b/src/functions/telemetry/telemetry.ts
@@ -1,39 +1,46 @@
-import {APIGatewayProxyEvent, APIGatewayProxyResult, Handler} from "aws-lambda";
-import {initSentry, sentryWrapHandler} from "../../lib/sentry";
-import {ROVER_AGENT, roverHandler} from "./rover";
-import {ROUTER_AGENT, routerHandler} from "./router";
+import {
+  APIGatewayProxyEvent,
+  APIGatewayProxyResult,
+  Handler,
+} from "aws-lambda";
+import { initSentry, sentryWrapHandler } from "../../lib/sentry";
+import { ROVER_AGENT, roverHandler } from "./rover";
+import { ROUTER_AGENT, routerHandler } from "./router";
 
 initSentry();
 
 export interface Platform {
-    // the platform from which the command was run (i.e. linux, macOS, or windows)
-    os: string;
-    // CI info
-    continuous_integration: string | null;
+  // the platform from which the command was run (i.e. linux, macOS, or windows)
+  os: string;
+  // CI info
+  continuous_integration: string | null;
 }
 
 export const MALFORMED_REQUEST = {
-    statusCode: 400,
-    body: "Malformed Request",
+  statusCode: 400,
+  body: "Malformed Request",
 };
 
 export const INVALID_PERMISSIONS = {
-    statusCode: 403,
-    body: "Invalid Permissions",
+  statusCode: 403,
+  body: "Invalid Permissions",
 };
 
 const handler: Handler<APIGatewayProxyEvent, APIGatewayProxyResult> = async (
-    event
+  event
 ) => {
-    const headers = event.headers;
-    const contentType = headers["content-type"];
-    const userAgent = headers["user-agent"];
+  const headers = event.headers;
+  const contentType = headers["content-type"];
+  const userAgent = headers["user-agent"];
 
-    if (!contentType || !contentType.includes("application/json")) return MALFORMED_REQUEST;
-    if (userAgent && userAgent.startsWith(ROVER_AGENT)) return await roverHandler(event, userAgent);
-    if (userAgent && userAgent.startsWith(ROUTER_AGENT)) return await routerHandler(event, userAgent);
+  if (!contentType || !contentType.includes("application/json"))
+    return MALFORMED_REQUEST;
+  if (userAgent && userAgent.startsWith(ROVER_AGENT))
+    return await roverHandler(event, userAgent);
+  if (userAgent && userAgent.startsWith(ROUTER_AGENT))
+    return await routerHandler(event, userAgent);
 
-    return INVALID_PERMISSIONS;
+  return INVALID_PERMISSIONS;
 };
 
 module.exports.handler = sentryWrapHandler(handler);

--- a/src/lib/__tests__/binary.ts
+++ b/src/lib/__tests__/binary.ts
@@ -1,6 +1,6 @@
 import nock from "nock";
 import { Binary, InputVersion } from "../binary";
-import {  MalformedRequestError } from "../error";
+import { MalformedRequestError } from "../error";
 import { downloadEvent } from "../download";
 
 const INSTALLER_CONTENTS = "installer contents";
@@ -11,24 +11,19 @@ beforeEach(() => {
 });
 
 const nockGitHubLatest = (binary: Binary, version: string) => {
-  let latestReleaseEndpoint = binary.repo.releaseUrl(new InputVersion("latest", binary.name))
-  let thisReleaseEndpoint = binary.repo.releaseUrl(new InputVersion(version, binary.name))
-  nock(latestReleaseEndpoint)
-    .head("")
-    .reply(302, undefined, {
-      Location: thisReleaseEndpoint,
-    });
+  let latestReleaseEndpoint = binary.repo.releaseUrl(
+    new InputVersion("latest", binary.name)
+  );
+  let thisReleaseEndpoint = binary.repo.releaseUrl(
+    new InputVersion(version, binary.name)
+  );
+  nock(latestReleaseEndpoint).head("").reply(302, undefined, {
+    Location: thisReleaseEndpoint,
+  });
 };
 
-const nockInstaller = (
-  binary: Binary,
-  version: string,
-  platform: string
-) => {
-  let githubInstallerEndpoint = binary.getInstallScriptUrl(
-    platform,
-    version
-  );
+const nockInstaller = (binary: Binary, version: string, platform: string) => {
+  let githubInstallerEndpoint = binary.getInstallScriptUrl(platform, version);
   nock(githubInstallerEndpoint).head("").reply(200, INSTALLER_CONTENTS);
 };
 
@@ -45,7 +40,7 @@ it("fetches latest version from a redirected url", async () => {
     "installer"
   );
   let version = res.headers["X-Version"];
-  let location = res.headers["Location"]
+  let location = res.headers["Location"];
   expect(version).toEqual("v0.99.99");
   expect(location).toContain("v0.99.99");
 });
@@ -64,8 +59,8 @@ it("returns proper version with /vx.x.x", async () => {
   );
   let location = res.headers["Location"];
   let version = res.headers["X-Version"];
-  expect(location).toContain("githubusercontent")
-  expect(location).toContain("v0.99.99")
+  expect(location).toContain("githubusercontent");
+  expect(location).toContain("v0.99.99");
   expect(version).toEqual("v0.99.99");
 });
 
@@ -73,12 +68,7 @@ it("errors when invalid platform passed", async () => {
   let realVersion = "v0.99.99";
   let platform = "myInvalidOS";
 
-  let res = await downloadEvent(
-    "rover",
-    platform,
-    realVersion,
-    "installer"
-  );
+  let res = await downloadEvent("rover", platform, realVersion, "installer");
   expect(res.body).toContain("invalid");
   expect(res.statusCode).toEqual(400);
 });
@@ -87,12 +77,7 @@ it("errors when invalid version passed", async () => {
   let version = "badbadversion";
   let platform = "nix";
 
-  let res = await downloadEvent(
-    "rover",
-    platform,
-    version,
-    "installer"
-  );
+  let res = await downloadEvent("rover", platform, version, "installer");
   expect(res.body).toContain("invalid");
   expect(res.statusCode).toEqual(400);
 });

--- a/src/lib/binary.ts
+++ b/src/lib/binary.ts
@@ -30,7 +30,8 @@ export class Binary {
         break;
       default:
         throw new MalformedRequestError(
-          `invalid binary name '${this.name
+          `invalid binary name '${
+            this.name
           }'. possible names are ${possibleValues(BinaryName)}`
         );
     }
@@ -42,17 +43,23 @@ export class Binary {
     version: string
   ): string {
     let targetTriple = enumFromStringValue(TargetTriple, inputTargetTriple);
-    if (targetTriple === TargetTriple.AppleArm && (this.name === BinaryName.Supergraph || this.name === BinaryName.Router)) {
-      throw new MalformedRequestError(`invalid target '${targetTriple}' for '${this.name}' binary, you should download the 'x86_64-apple-darwin' target instead and it will work on Mac machines with Apple's ARM processor via emulation.`)
+    if (
+      targetTriple === TargetTriple.AppleArm &&
+      (this.name === BinaryName.Supergraph || this.name === BinaryName.Router)
+    ) {
+      throw new MalformedRequestError(
+        `invalid target '${targetTriple}' for '${this.name}' binary, you should download the 'x86_64-apple-darwin' target instead and it will work on Mac machines with Apple's ARM processor via emulation.`
+      );
     }
     return `${this.name}-${version}-${targetTriple}.tar.gz`;
   }
 
   getReleaseTarballUrl(inputTargetTriple: string, version: string): string {
-    return `https://github.com/${this.repo.slug
-      }/releases/download/${this.getReleaseTagName(
-        version
-      )}/${this.getReleaseTarballName(inputTargetTriple, version)}`;
+    return `https://github.com/${
+      this.repo.slug
+    }/releases/download/${this.getReleaseTagName(
+      version
+    )}/${this.getReleaseTarballName(inputTargetTriple, version)}`;
   }
 
   async getFullyQualifiedRoverVersion(fetch: Fetcher): Promise<string> {
@@ -85,10 +92,12 @@ export class Binary {
   async getFullyQualifiedSupergraphVersion(
     fetch: Fetcher,
     version: string
-  ): Promise<string> {    
+  ): Promise<string> {
     // supergraph is a bit weird because we have a "latest" for fed 1 _and_ for fed 2
     // the source of truth for these is on the `main` branch of https://github.com/apollographql/rover in the ./latest_plugin_versions.json file
-    let latestPluginVersions = await fetch("https://raw.githubusercontent.com/apollographql/rover/main/latest_plugin_versions.json");
+    let latestPluginVersions = await fetch(
+      "https://raw.githubusercontent.com/apollographql/rover/main/latest_plugin_versions.json"
+    );
     let supergraphJson = await latestPluginVersions.json();
     let supergraphVersions = supergraphJson["supergraph"]["versions"];
     let latestTag: string;
@@ -114,7 +123,7 @@ export class Binary {
   async getFullyQualifiedRouterVersion(
     fetch: Fetcher,
     version: string
-  ): Promise<string> {    
+  ): Promise<string> {
     let latestTag: string;
     // for the "latest" router, we query github releases to get the most recent release
     if (version === "latest") {
@@ -142,10 +151,12 @@ export class Binary {
           `something went wrong while fetching ${versionUrl}`
         );
       }
-    // rover will request this latest-plugin version to use the version specified in latest_plugin_versions.json
+      // rover will request this latest-plugin version to use the version specified in latest_plugin_versions.json
     } else if (version === "latest-plugin") {
       // the source of truth for the latest router versions is on the `main` branch of https://github.com/apollographql/rover in the ./latest_plugin_versions.json file
-      let latestPluginVersions = await fetch("https://raw.githubusercontent.com/apollographql/rover/main/latest_plugin_versions.json");
+      let latestPluginVersions = await fetch(
+        "https://raw.githubusercontent.com/apollographql/rover/main/latest_plugin_versions.json"
+      );
       let supergraphJson = await latestPluginVersions.json();
       let supergraphVersions = supergraphJson["router"]["versions"];
       latestTag = supergraphVersions["latest-1"];
@@ -190,7 +201,8 @@ export class Binary {
 
       default:
         throw new MalformedRequestError(
-          `invalid binary name '${this.name
+          `invalid binary name '${
+            this.name
           }'. possible names are ${possibleValues(BinaryName)}`
         );
     }
@@ -233,7 +245,8 @@ export class Binary {
         );
       default:
         throw new MalformedRequestError(
-          `invalid binary name '${this.name
+          `invalid binary name '${
+            this.name
           }'. possible names are ${possibleValues(BinaryName)}`
         );
     }
@@ -320,7 +333,10 @@ export class InputVersion {
       (version === "latest-0" || version === "latest-2")
     ) {
       this.descriptor = version;
-    } else if (binaryName === BinaryName.Router && version === "latest-plugin") {
+    } else if (
+      binaryName === BinaryName.Router &&
+      version === "latest-plugin"
+    ) {
       this.descriptor = version;
     } else {
       throw new MalformedRequestError(

--- a/src/lib/error.ts
+++ b/src/lib/error.ts
@@ -2,7 +2,7 @@ export class HttpError implements Error {
   name: string;
   message: string;
   status: number;
-  constructor(opts: {name: string, message: string, status: number}) {
+  constructor(opts: { name: string; message: string; status: number }) {
     this.name = opts.name;
     this.message = opts.message;
     this.status = opts.status;
@@ -11,19 +11,30 @@ export class HttpError implements Error {
 
 export class MalformedRequestError extends HttpError {
   constructor(message: string) {
-    super({message: `malformed request: ${message}`, name: "MalformedRequestError", status: 400})
+    super({
+      message: `malformed request: ${message}`,
+      name: "MalformedRequestError",
+      status: 400,
+    });
   }
 }
 
 export class NotFoundError extends HttpError {
   constructor(message: string) {
-    super({message: `asset not found: ${message}`, name: "NotFoundError", status: 404})
+    super({
+      message: `asset not found: ${message}`,
+      name: "NotFoundError",
+      status: 404,
+    });
   }
 }
 
 export class InternalServerError extends HttpError {
   constructor(message: string) {
-    super({ message: `internal server error: ${message}`, name: "InternalServerError", status: 500})
+    super({
+      message: `internal server error: ${message}`,
+      name: "InternalServerError",
+      status: 500,
+    });
   }
 }
-

--- a/src/lib/track.ts
+++ b/src/lib/track.ts
@@ -1,5 +1,5 @@
 import { request } from "graphql-request";
-import {DocumentNode} from "graphql";
+import { DocumentNode } from "graphql";
 const graphQLEndpoint = "https://graphql.api.apollographql.com/api/graphql";
 
 const STUDIO_API_KEY = process.env["STUDIO_API_KEY"];


### PR DESCRIPTION
# This must land as a true-merge commit to main
# And https://github.com/apollographql/orbiter/pull/68 must merge first.
The script is fixed with https://github.com/apollographql/orbiter/pull/68 so
this just does the actual fix and adds the prettiering commit to a
`.git-blame-ignore-revs` file in a follow-up so that this commit will not
permanently mask the underlying changes that actually mattered for non-humans.

Docs for `.git-blame-ignore-revs` if anyone is interested:
  https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view
