### PR TITLE
feat: Add `/templates` as a path pointing to the new DX supergraph (for use from Rover)

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -23,3 +23,4 @@ https://rover.apollo.dev/ https://www.apollographql.com/docs/rover 302
 https://rover.apollo.dev/quickstart https://www.apollographql.com/docs/federation/quickstart
 https://rover.apollo.dev/quickstart/products/graphql https://7bssbnldib.execute-api.us-east-1.amazonaws.com/Prod/graphql 200!
 https://rover.apollo.dev/quickstart/reviews/graphql https://w0jtezo2pa.execute-api.us-east-1.amazonaws.com/Prod/graphql 200!
+https://rover.apollo.dev/templates https://main--apollo-dx.apollographos.net/graphql 200!


### PR DESCRIPTION
cc @EverlastingBugstopper who recommended this 😁 