### PR TITLE
Remove test domains

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -6,12 +6,6 @@ https://rover.apollo.dev/win/* /.netlify/functions/install-rover 200!
 https://rover.apollo.dev/nix/* /.netlify/functions/install-rover 200!
 https://rover.apollo.dev/plugins/* /.netlify/functions/install-plugin 200!
 
-# Test domains
-https://rover.starstuff.dev/tar/* /.netlify/functions/tar 200!
-https://rover.starstuff.dev/win/* /.netlify/functions/install-rover 200!
-https://rover.starstuff.dev/nix/* /.netlify/functions/install-rover 200!
-https://rover.starstuff.dev/plugins/* /.netlify/functions/install-plugin 200!
-
 # Doesn't yet have a specific host.  Probably going to be used for Rover AND Router.
 /telemetry /.netlify/functions/telemetry 200!
 


### PR DESCRIPTION
Reverting these recent additions.  These were briefly added during an outage to test the Edge CDN, however, they didn't prove effective.  Most notably because the CDN couldn't have saved us in this particular case, especially since we didn't deliver `cache-control` headers with the redirects which, themselves, could have been cached.

Reverts: https://github.com/apollographql/orbiter/commit/d60841ec4f95f50ebbb0a2bb142d6d1e2cc5d5b1