### PR TITLE
Set `Cache-Control` headers on the redirects so they themselves can be cached

### DIFF
--- a/src/functions/download-router/download-router.test.ts
+++ b/src/functions/download-router/download-router.test.ts
@@ -28,7 +28,7 @@ it("pulls from a version if passed", async () => {
 
   expect(res.statusCode).toEqual(302);
   expect(res.headers["X-Version"]).toEqual("v0.9.0-rc.0");
-  expect(res.headers["Cache-Control"]).toEqual("max-age=60, stale-if-error=30, stale-while-revalidate=30");
+  expect(res.headers["Cache-Control"]).toEqual("max-age=60, stale-if-error=18000, stale-while-revalidate=30");
   expect(res.headers["Location"]).toContain("v0.9.0-rc.0");
 });
 

--- a/src/functions/download-router/download-router.test.ts
+++ b/src/functions/download-router/download-router.test.ts
@@ -28,6 +28,7 @@ it("pulls from a version if passed", async () => {
 
   expect(res.statusCode).toEqual(302);
   expect(res.headers["X-Version"]).toEqual("v0.9.0-rc.0");
+  expect(res.headers["Cache-Control"]).toEqual("max-age=60, stale-if-error=30, stale-while-revalidate=30");
   expect(res.headers["Location"]).toContain("v0.9.0-rc.0");
 });
 
@@ -37,6 +38,7 @@ it("returns a 400 if no version is passed", async () => {
   });
 
   expect(res.statusCode).toEqual(400);
+  expect(res.headers?.["Cache-Control"]).toBeUndefined();
   expect(res.body).toContain("version");
 });
 
@@ -46,6 +48,7 @@ it("returns a 400 if no platform is passed", async () => {
   });
 
   expect(res.statusCode).toEqual(400);
+  expect(res.headers?.["Cache-Control"]).toBeUndefined();
   expect(res.body).toContain("platform");
 });
 
@@ -57,6 +60,7 @@ it("returns a 500 if GitHub is down", async () => {
   });
 
   expect(res.statusCode).toEqual(500);
+  expect(res.headers?.["Cache-Control"]).toBeUndefined();
   expect(res.body).toContain("Internal Server Error");
 });
 
@@ -69,6 +73,7 @@ it("returns a 400 if asking for a bad version", async () => {
   });
 
   expect(res.statusCode).toEqual(400);
+  expect(res.headers?.["Cache-Control"]).toBeUndefined();
   expect(res.body).toContain("invalid version");
 });
 
@@ -80,5 +85,6 @@ it("returns a 404 if asking for a nonexistent version", async () => {
   });
 
   expect(res.statusCode).toEqual(404);
+  expect(res.headers?.["Cache-Control"]).toBeUndefined();
   expect(res.body).toContain("couldn't find a GitHub release");
 });

--- a/src/functions/install-rover/install-rover.test.ts
+++ b/src/functions/install-rover/install-rover.test.ts
@@ -28,7 +28,7 @@ it("pulls from a version if passed", async () => {
 
   expect(res.statusCode).toEqual(302);
   expect(res.headers["X-Version"]).toEqual("v0.0.1");
-  expect(res.headers?.["Cache-Control"]).toEqual("max-age=60, stale-if-error=30, stale-while-revalidate=30")
+  expect(res.headers?.["Cache-Control"]).toEqual("max-age=60, stale-if-error=18000, stale-while-revalidate=30")
   expect(res.headers["Location"]).toContain("v0.0.1");
 });
 

--- a/src/functions/install-rover/install-rover.test.ts
+++ b/src/functions/install-rover/install-rover.test.ts
@@ -28,6 +28,7 @@ it("pulls from a version if passed", async () => {
 
   expect(res.statusCode).toEqual(302);
   expect(res.headers["X-Version"]).toEqual("v0.0.1");
+  expect(res.headers?.["Cache-Control"]).toEqual("max-age=60, stale-if-error=30, stale-while-revalidate=30")
   expect(res.headers["Location"]).toContain("v0.0.1");
 });
 
@@ -37,6 +38,7 @@ it("returns a 400 if no version is passed", async () => {
   });
 
   expect(res.statusCode).toEqual(400);
+  expect(res.headers?.["Cache-Control"]).toBeUndefined();
   expect(res.body).toContain("version");
 });
 
@@ -46,6 +48,7 @@ it("returns a 400 if no platform is passed", async () => {
   });
 
   expect(res.statusCode).toEqual(400);
+  expect(res.headers?.["Cache-Control"]).toBeUndefined();
   expect(res.body).toContain("platform");
 });
 
@@ -57,6 +60,7 @@ it("returns a 500 if GitHub is down", async () => {
   });
 
   expect(res.statusCode).toEqual(500);
+  expect(res.headers?.["Cache-Control"]).toBeUndefined();
   expect(res.body).toContain("Internal Server Error");
 });
 
@@ -69,6 +73,7 @@ it("returns a 400 if asking for a bad version", async () => {
   });
 
   expect(res.statusCode).toEqual(400);
+  expect(res.headers?.["Cache-Control"]).toBeUndefined();
   expect(res.body).toContain("invalid version");
 });
 
@@ -80,5 +85,6 @@ it("returns a 404 if asking for a nonexistent version", async () => {
   });
 
   expect(res.statusCode).toEqual(404);
+  expect(res.headers?.["Cache-Control"]).toBeUndefined();
   expect(res.body).toContain("couldn't find a GitHub release");
 });

--- a/src/functions/legacy-cli/legacy-cli.test.ts
+++ b/src/functions/legacy-cli/legacy-cli.test.ts
@@ -27,6 +27,7 @@ it("pulls from a version if passed", async () => {
   });
 
   expect(res.statusCode).toEqual(301);
+  expect(res.headers?.["Cache-Control"]).toBeUndefined();
   expect(res.body).toContain("Redirecting");
 });
 
@@ -40,6 +41,7 @@ it("returns a 500 if no version is passed", async () => {
   });
 
   expect(res.statusCode).toEqual(400);
+  expect(res.headers?.["Cache-Control"]).toBeUndefined();
   expect(res.body).toContain("Missing");
 });
 
@@ -53,6 +55,7 @@ it("returns a 500 if no platform is passed", async () => {
   });
 
   expect(res.statusCode).toEqual(400);
+  expect(res.headers?.["Cache-Control"]).toBeUndefined();
   expect(res.body).toContain("Missing");
 });
 
@@ -66,6 +69,7 @@ it("returns a 500 if GitHub is down", async () => {
   });
 
   expect(res.statusCode).toEqual(500);
+  expect(res.headers?.["Cache-Control"]).toBeUndefined();
   expect(res.body).toContain("Internal Server Error");
 });
 
@@ -81,5 +85,6 @@ it("returns a 500 if asking for a bad version", async () => {
   });
 
   expect(res.statusCode).toEqual(500);
+  expect(res.headers?.["Cache-Control"]).toBeUndefined();
   expect(res.body).toContain("Internal Server Error");
 });

--- a/src/lib/__tests__/binary.ts
+++ b/src/lib/__tests__/binary.ts
@@ -39,9 +39,11 @@ it("fetches latest version from a redirected url", async () => {
     "latest",
     "installer"
   );
-  let version = res.headers["X-Version"];
-  let location = res.headers["Location"];
+  let version = res.headers?.["X-Version"];
+  let cacheControl = res.headers?.["Cache-Control"];
+  let location = res.headers?.["Location"];
   expect(version).toEqual("v0.99.99");
+  expect(cacheControl).toEqual("max-age=60, stale-if-error=30, stale-while-revalidate=30");
   expect(location).toContain("v0.99.99");
 });
 
@@ -57,10 +59,12 @@ it("returns proper version with /vx.x.x", async () => {
     realVersion,
     "installer"
   );
-  let location = res.headers["Location"];
-  let version = res.headers["X-Version"];
+  let location = res.headers?.["Location"];
+  let cacheControl = res.headers?.["Cache-Control"];
+  let version = res.headers?.["X-Version"];
   expect(location).toContain("githubusercontent");
   expect(location).toContain("v0.99.99");
+  expect(cacheControl).toContain("max-age=60, stale-if-error=30, stale-while-revalidate=30");
   expect(version).toEqual("v0.99.99");
 });
 
@@ -69,7 +73,9 @@ it("errors when invalid platform passed", async () => {
   let platform = "myInvalidOS";
 
   let res = await downloadEvent("rover", platform, realVersion, "installer");
+  let cacheControl = res.headers?.["Cache-Control"];
   expect(res.body).toContain("invalid");
+  expect(cacheControl).toBeUndefined()
   expect(res.statusCode).toEqual(400);
 });
 
@@ -78,6 +84,8 @@ it("errors when invalid version passed", async () => {
   let platform = "nix";
 
   let res = await downloadEvent("rover", platform, version, "installer");
+  let cacheControl = res.headers?.["Cache-Control"];
   expect(res.body).toContain("invalid");
+  expect(cacheControl).toBeUndefined();
   expect(res.statusCode).toEqual(400);
 });

--- a/src/lib/__tests__/binary.ts
+++ b/src/lib/__tests__/binary.ts
@@ -43,7 +43,7 @@ it("fetches latest version from a redirected url", async () => {
   let cacheControl = res.headers?.["Cache-Control"];
   let location = res.headers?.["Location"];
   expect(version).toEqual("v0.99.99");
-  expect(cacheControl).toEqual("max-age=60, stale-if-error=30, stale-while-revalidate=30");
+  expect(cacheControl).toEqual("max-age=60, stale-if-error=18000, stale-while-revalidate=30");
   expect(location).toContain("v0.99.99");
 });
 
@@ -64,7 +64,7 @@ it("returns proper version with /vx.x.x", async () => {
   let version = res.headers?.["X-Version"];
   expect(location).toContain("githubusercontent");
   expect(location).toContain("v0.99.99");
-  expect(cacheControl).toContain("max-age=60, stale-if-error=30, stale-while-revalidate=30");
+  expect(cacheControl).toContain("max-age=60, stale-if-error=18000, stale-while-revalidate=30");
   expect(version).toEqual("v0.99.99");
 });
 

--- a/src/lib/download.ts
+++ b/src/lib/download.ts
@@ -45,7 +45,7 @@ export async function downloadEvent(
         body: `You are being redirected to ${endpoint}`,
         headers: {
           Location: endpoint,
-          "Cache-Control": "max-age=60, stale-if-error=30, stale-while-revalidate=30",
+          "Cache-Control": "max-age=60, stale-if-error=18000, stale-while-revalidate=30",
           "X-Version": version,
         },
       };

--- a/src/lib/download.ts
+++ b/src/lib/download.ts
@@ -45,6 +45,7 @@ export async function downloadEvent(
         body: `You are being redirected to ${endpoint}`,
         headers: {
           Location: endpoint,
+          "Cache-Control": "max-age=60, stale-if-error=30, stale-while-revalidate=30",
           "X-Version": version,
         },
       };


### PR DESCRIPTION
In the event that the underlying function cannot be invoked (for example, an AWS us-east-1 outage or a Netlify rate-limiting event), we can let intermediary CDNs (like the Netlify CDN that sits in front of our functions, or even another CDN that we add in front of that CDN, in theory) serve "stale", yet valid content that has been generated recently.

In our case (and this functions case) the cached content is really just the `Location:` header that gets sent back as a HTTP response, but even caching that is valuable in an outage since GitHub release artifacts might still be up.  In the future, we can add other caching layers, including to GitHub Artifacts themselves (E.g., falling back to S3 or GCS), but this doesn't try to do that.
