### PR TITLE
URGENT: Mitigate rover dev outage: router tarball download url on x86_64 linux

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,25 +1,32 @@
 # Netlify's functions are invoked at `/.netlify/functions/fn-name`, which is
-# definitely not ideal, and we'd like to also hide the provider (netlify) in the
-# url. This adds a transparent "200" proxy from root locations to actual functions
-https://rover.apollo.dev/tar/* /.netlify/functions/tar 200!
-https://rover.apollo.dev/win/* /.netlify/functions/install-rover 200!
-https://rover.apollo.dev/nix/* /.netlify/functions/install-rover 200!
-https://rover.apollo.dev/plugins/* /.netlify/functions/install-plugin 200!
 
-# Doesn't yet have a specific host.  Probably going to be used for Rover AND Router.
+# definitely not ideal, and we'd like to also hide the provider (netlify) in the
+
+# url. This adds a transparent "200" proxy from root locations to actual functions
+
+https://deploy-preview-91--apollo-orbiter.netlify.app/tar/_ /.netlify/functions/tar 200!
+https://deploy-preview-91--apollo-orbiter.netlify.app/win/_ /.netlify/functions/install-rover 200!
+https://deploy-preview-91--apollo-orbiter.netlify.app/nix/_ /.netlify/functions/install-rover 200!
+https://deploy-preview-91--apollo-orbiter.netlify.app/plugins/_ /.netlify/functions/install-plugin 200!
+
+# Doesn't yet have a specific host. Probably going to be used for Rover AND Router.
+
 /telemetry /.netlify/functions/telemetry 200!
 
 https://install.apollographql.com/legacy-cli/* /.netlify/functions/legacy-cli 200!
 
 # These are for the Router despite the `/download/` prefix.
+
 # Working plan is to use domain-based redirects to accomplish this.
+
 https://router.apollo.dev/download/nix/* /.netlify/functions/download-router 200!
 
 # Non-Functions
-https://router.apollo.dev/ https://www.apollographql.com/docs/router/quickstart 302
-https://rover.apollo.dev/ https://www.apollographql.com/docs/rover 302
 
-https://rover.apollo.dev/quickstart https://www.apollographql.com/docs/federation/quickstart
-https://rover.apollo.dev/quickstart/products/graphql https://7bssbnldib.execute-api.us-east-1.amazonaws.com/Prod/graphql 200!
-https://rover.apollo.dev/quickstart/reviews/graphql https://w0jtezo2pa.execute-api.us-east-1.amazonaws.com/Prod/graphql 200!
-https://rover.apollo.dev/templates https://main--apollo-dx.apollographos.net/graphql 200!
+https://router.apollo.dev/ https://www.apollographql.com/docs/router/quickstart 302
+https://deploy-preview-91--apollo-orbiter.netlify.app/ https://www.apollographql.com/docs/rover 302
+
+https://deploy-preview-91--apollo-orbiter.netlify.app/quickstart https://www.apollographql.com/docs/federation/quickstart
+https://deploy-preview-91--apollo-orbiter.netlify.app/quickstart/products/graphql https://7bssbnldib.execute-api.us-east-1.amazonaws.com/Prod/graphql 200!
+https://deploy-preview-91--apollo-orbiter.netlify.app/quickstart/reviews/graphql https://w0jtezo2pa.execute-api.us-east-1.amazonaws.com/Prod/graphql 200!
+https://deploy-preview-91--apollo-orbiter.netlify.app/templates https://main--apollo-dx.apollographos.net/graphql 200!

--- a/_redirects
+++ b/_redirects
@@ -1,10 +1,10 @@
 # Netlify's functions are invoked at `/.netlify/functions/fn-name`, which is
 # definitely not ideal, and we'd like to also hide the provider (netlify) in the
 # url. This adds a transparent "200" proxy from root locations to actual functions
-https://rover.apollo.dev/tar/* /.netlify/functions/tar 200!
-https://rover.apollo.dev/win/* /.netlify/functions/install-rover 200!
-https://rover.apollo.dev/nix/* /.netlify/functions/install-rover 200!
-https://rover.apollo.dev/plugins/* /.netlify/functions/install-plugin 200!
+https://deploy-preview-91--apollo-orbiter.netlify.app/tar/* /.netlify/functions/tar 200!
+https://deploy-preview-91--apollo-orbiter.netlify.app/win/* /.netlify/functions/install-rover 200!
+https://deploy-preview-91--apollo-orbiter.netlify.app/nix/* /.netlify/functions/install-rover 200!
+https://deploy-preview-91--apollo-orbiter.netlify.app/plugins/* /.netlify/functions/install-plugin 200!
 
 # Doesn't yet have a specific host.  Probably going to be used for Rover AND Router.
 /telemetry /.netlify/functions/telemetry 200!
@@ -17,9 +17,9 @@ https://router.apollo.dev/download/nix/* /.netlify/functions/download-router 200
 
 # Non-Functions
 https://router.apollo.dev/ https://www.apollographql.com/docs/router/quickstart 302
-https://rover.apollo.dev/ https://www.apollographql.com/docs/rover 302
+https://deploy-preview-91--apollo-orbiter.netlify.app/ https://www.apollographql.com/docs/rover 302
 
-https://rover.apollo.dev/quickstart https://www.apollographql.com/docs/federation/quickstart
-https://rover.apollo.dev/quickstart/products/graphql https://7bssbnldib.execute-api.us-east-1.amazonaws.com/Prod/graphql 200!
-https://rover.apollo.dev/quickstart/reviews/graphql https://w0jtezo2pa.execute-api.us-east-1.amazonaws.com/Prod/graphql 200!
-https://rover.apollo.dev/templates https://main--apollo-dx.apollographos.net/graphql 200!
+https://deploy-preview-91--apollo-orbiter.netlify.app/quickstart https://www.apollographql.com/docs/federation/quickstart
+https://deploy-preview-91--apollo-orbiter.netlify.app/quickstart/products/graphql https://7bssbnldib.execute-api.us-east-1.amazonaws.com/Prod/graphql 200!
+https://deploy-preview-91--apollo-orbiter.netlify.app/quickstart/reviews/graphql https://w0jtezo2pa.execute-api.us-east-1.amazonaws.com/Prod/graphql 200!
+https://deploy-preview-91--apollo-orbiter.netlify.app/templates https://main--apollo-dx.apollographos.net/graphql 200!

--- a/_redirects
+++ b/_redirects
@@ -1,28 +1,21 @@
 # Netlify's functions are invoked at `/.netlify/functions/fn-name`, which is
-
 # definitely not ideal, and we'd like to also hide the provider (netlify) in the
-
 # url. This adds a transparent "200" proxy from root locations to actual functions
+https://deploy-preview-91--apollo-orbiter.netlify.app/tar/* /.netlify/functions/tar 200!
+https://deploy-preview-91--apollo-orbiter.netlify.app/win/* /.netlify/functions/install-rover 200!
+https://deploy-preview-91--apollo-orbiter.netlify.app/nix/* /.netlify/functions/install-rover 200!
+https://deploy-preview-91--apollo-orbiter.netlify.app/plugins/* /.netlify/functions/install-plugin 200!
 
-https://deploy-preview-91--apollo-orbiter.netlify.app/tar/_ /.netlify/functions/tar 200!
-https://deploy-preview-91--apollo-orbiter.netlify.app/win/_ /.netlify/functions/install-rover 200!
-https://deploy-preview-91--apollo-orbiter.netlify.app/nix/_ /.netlify/functions/install-rover 200!
-https://deploy-preview-91--apollo-orbiter.netlify.app/plugins/_ /.netlify/functions/install-plugin 200!
-
-# Doesn't yet have a specific host. Probably going to be used for Rover AND Router.
-
+# Doesn't yet have a specific host.  Probably going to be used for Rover AND Router.
 /telemetry /.netlify/functions/telemetry 200!
 
 https://install.apollographql.com/legacy-cli/* /.netlify/functions/legacy-cli 200!
 
 # These are for the Router despite the `/download/` prefix.
-
 # Working plan is to use domain-based redirects to accomplish this.
-
 https://router.apollo.dev/download/nix/* /.netlify/functions/download-router 200!
 
 # Non-Functions
-
 https://router.apollo.dev/ https://www.apollographql.com/docs/router/quickstart 302
 https://deploy-preview-91--apollo-orbiter.netlify.app/ https://www.apollographql.com/docs/rover 302
 

--- a/_redirects
+++ b/_redirects
@@ -1,10 +1,10 @@
 # Netlify's functions are invoked at `/.netlify/functions/fn-name`, which is
 # definitely not ideal, and we'd like to also hide the provider (netlify) in the
 # url. This adds a transparent "200" proxy from root locations to actual functions
-https://deploy-preview-91--apollo-orbiter.netlify.app/tar/* /.netlify/functions/tar 200!
-https://deploy-preview-91--apollo-orbiter.netlify.app/win/* /.netlify/functions/install-rover 200!
-https://deploy-preview-91--apollo-orbiter.netlify.app/nix/* /.netlify/functions/install-rover 200!
-https://deploy-preview-91--apollo-orbiter.netlify.app/plugins/* /.netlify/functions/install-plugin 200!
+https://rover.apollo.dev/tar/* /.netlify/functions/tar 200!
+https://rover.apollo.dev/win/* /.netlify/functions/install-rover 200!
+https://rover.apollo.dev/nix/* /.netlify/functions/install-rover 200!
+https://rover.apollo.dev/plugins/* /.netlify/functions/install-plugin 200!
 
 # Doesn't yet have a specific host.  Probably going to be used for Rover AND Router.
 /telemetry /.netlify/functions/telemetry 200!
@@ -17,9 +17,9 @@ https://router.apollo.dev/download/nix/* /.netlify/functions/download-router 200
 
 # Non-Functions
 https://router.apollo.dev/ https://www.apollographql.com/docs/router/quickstart 302
-https://deploy-preview-91--apollo-orbiter.netlify.app/ https://www.apollographql.com/docs/rover 302
+https://rover.apollo.dev/ https://www.apollographql.com/docs/rover 302
 
-https://deploy-preview-91--apollo-orbiter.netlify.app/quickstart https://www.apollographql.com/docs/federation/quickstart
-https://deploy-preview-91--apollo-orbiter.netlify.app/quickstart/products/graphql https://7bssbnldib.execute-api.us-east-1.amazonaws.com/Prod/graphql 200!
-https://deploy-preview-91--apollo-orbiter.netlify.app/quickstart/reviews/graphql https://w0jtezo2pa.execute-api.us-east-1.amazonaws.com/Prod/graphql 200!
-https://deploy-preview-91--apollo-orbiter.netlify.app/templates https://main--apollo-dx.apollographos.net/graphql 200!
+https://rover.apollo.dev/quickstart https://www.apollographql.com/docs/federation/quickstart
+https://rover.apollo.dev/quickstart/products/graphql https://7bssbnldib.execute-api.us-east-1.amazonaws.com/Prod/graphql 200!
+https://rover.apollo.dev/quickstart/reviews/graphql https://w0jtezo2pa.execute-api.us-east-1.amazonaws.com/Prod/graphql 200!
+https://rover.apollo.dev/templates https://main--apollo-dx.apollographos.net/graphql 200!

--- a/src/lib/download.ts
+++ b/src/lib/download.ts
@@ -38,8 +38,14 @@ export async function downloadEvent(
         "You must either download a tarball or an install script"
       );
     }
-    let response = await fetch(endpoint, { method: "HEAD" });
-    if (response.ok) {
+    // Do not follow redirect,
+    // just make sure the endpoint is ready
+    // to receive the client's call
+    let response = await fetch(endpoint, {
+      method: "HEAD",
+      redirect: "manual",
+    });
+    if (response.ok || response.status === 302) {
       return {
         statusCode: 302,
         body: `You are being redirected to ${endpoint}`,


### PR DESCRIPTION
We are currently experiencing an outage that is impacting `rover dev` usage on Linux because of an upstream change that is impacting `HEAD` requests differently than `GET` requests.

Previously, the `fetch` implementation was itself following redirects, based on the version of `make-fetch-happen` that we use (8).  Newer versions use `manual` by default, but we don't use those versions.