### PR TITLE
Modify orbiter to support router darwin binary changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ Valid target triples are as follows:
 |---|---|---|---|---|---|---|
 |rover|✅|✅|✅|✅|✅|✅|
 |supergraph|✅|❌|✅|✅|✅|❌|
-|router|✅|❌|✅|✅|✅|❌|
+|router|✅|❌|✅|✅|✅|✅|
+
+Note: router supported `x86_64-apple-darwin` until version `1.37.0`. For subsequent releases, the router supports `aarch64-apple-darwin`.
 
 Valid versions are as follows:
 

--- a/src/lib/binary.ts
+++ b/src/lib/binary.ts
@@ -44,8 +44,7 @@ export class Binary {
   ): string {
     let targetTriple = enumFromStringValue(TargetTriple, inputTargetTriple);
     if (
-      targetTriple === TargetTriple.AppleArm &&
-      (this.name === BinaryName.Supergraph || this.name === BinaryName.Router)
+      targetTriple === TargetTriple.AppleArm && this.name === BinaryName.Supergraph
     ) {
       throw new MalformedRequestError(
         `invalid target '${targetTriple}' for '${this.name}' binary, you should download the 'x86_64-apple-darwin' target instead and it will work on Mac machines with Apple's ARM processor via emulation.`


### PR DESCRIPTION
The router now provides aarch64-apple-darwin binaries and no longer provides x86_64-apple-darwin binaries.

Update orbiter to reflect this change.