### PR TITLE
OSX: Make sure orbiter serves the right osx architectures for router versions.

### DIFF
--- a/src/lib/__tests__/binary.ts
+++ b/src/lib/__tests__/binary.ts
@@ -75,7 +75,7 @@ it("errors when invalid platform passed", async () => {
   let res = await downloadEvent("rover", platform, realVersion, "installer");
   let cacheControl = res.headers?.["Cache-Control"];
   expect(res.body).toContain("invalid");
-  expect(cacheControl).toBeUndefined()
+  expect(cacheControl).toBeUndefined();
   expect(res.statusCode).toEqual(400);
 });
 
@@ -88,4 +88,40 @@ it("errors when invalid version passed", async () => {
   expect(res.body).toContain("invalid");
   expect(cacheControl).toBeUndefined();
   expect(res.statusCode).toEqual(400);
+});
+
+it("fetches arm only for router 1.38.0 and 1.39.0", async () => {
+  const appleAmdTriplet = "x86_64-apple-darwin";
+  const appleArmTriplet = "aarch64-apple-darwin";
+
+  const version = "v1.39.1";
+  const routerBinary = new Binary("router", version);
+
+  const validRoutersForOSXx64 = ["v1.37.0", "v1.39.1"];
+  const validRoutersForOSXarmOnly = ["v1.38.0", "v1.39.0"];
+
+  for (const r of validRoutersForOSXx64) {
+    const actualAmd = routerBinary.getReleaseTarballUrl(appleAmdTriplet, r);
+    const actualArm = routerBinary.getReleaseTarballUrl(appleArmTriplet, r);
+
+    expect(actualAmd).toBe(
+      `https://github.com/apollographql/router/releases/download/${r}/router-${r}-x86_64-apple-darwin.tar.gz`
+    );
+    expect(actualArm).toBe(
+      `https://github.com/apollographql/router/releases/download/${r}/router-${r}-aarch64-apple-darwin.tar.gz`
+    );
+  }
+
+  for (const r of validRoutersForOSXarmOnly) {
+    const actualArm = routerBinary.getReleaseTarballUrl(appleArmTriplet, r);
+
+    expect(actualArm).toBe(
+      `https://github.com/apollographql/router/releases/download/${r}/router-${r}-aarch64-apple-darwin.tar.gz`
+    );
+    expect(() => {
+      routerBinary.getReleaseTarballUrl(appleAmdTriplet, r);
+    }).toThrow(
+      "malformed request: invalid target 'x86_64-apple-darwin' for 'router' binary, you should download the 'x86_64-apple-darwin' target for router v1.39.1 or later, and it will work on all Mac machines thanks to universal binary."
+    );
+  }
 });

--- a/src/lib/__tests__/binary.ts
+++ b/src/lib/__tests__/binary.ts
@@ -43,7 +43,9 @@ it("fetches latest version from a redirected url", async () => {
   let cacheControl = res.headers?.["Cache-Control"];
   let location = res.headers?.["Location"];
   expect(version).toEqual("v0.99.99");
-  expect(cacheControl).toEqual("max-age=60, stale-if-error=18000, stale-while-revalidate=30");
+  expect(cacheControl).toEqual(
+    "max-age=60, stale-if-error=18000, stale-while-revalidate=30"
+  );
   expect(location).toContain("v0.99.99");
 });
 
@@ -64,7 +66,9 @@ it("returns proper version with /vx.x.x", async () => {
   let version = res.headers?.["X-Version"];
   expect(location).toContain("githubusercontent");
   expect(location).toContain("v0.99.99");
-  expect(cacheControl).toContain("max-age=60, stale-if-error=18000, stale-while-revalidate=30");
+  expect(cacheControl).toContain(
+    "max-age=60, stale-if-error=18000, stale-while-revalidate=30"
+  );
   expect(version).toEqual("v0.99.99");
 });
 
@@ -121,7 +125,7 @@ it("fetches arm only for router 1.38.0 and 1.39.0", async () => {
     expect(() => {
       routerBinary.getReleaseTarballUrl(appleAmdTriplet, r);
     }).toThrow(
-      "malformed request: invalid target 'x86_64-apple-darwin' for 'router' binary, you should download the 'x86_64-apple-darwin' target for router v1.39.1 or later, and it will work on all Mac machines thanks to universal binary."
+      "malformed request: invalid target 'x86_64-apple-darwin' for 'router' binary, you should download the 'x86_64-apple-darwin' target for router v1.39.1 or later."
     );
   }
 });

--- a/src/lib/binary.ts
+++ b/src/lib/binary.ts
@@ -6,7 +6,7 @@ import {
 } from "./error";
 import { getFetcher } from "./getFetcher";
 
-const OSX_ONLY_ROUTER_VERSIONS = ["v1.38.0", "v1.39.0"];
+const OSX_AARCH_ONLY_ROUTER_VERSIONS = ["v1.38.0", "v1.39.0"];
 
 export class Binary {
   name: BinaryName;
@@ -67,7 +67,7 @@ export class Binary {
   private isAppleArmOnlyRouter(version: string): boolean {
     return (
       this.name === BinaryName.Router &&
-      OSX_ONLY_ROUTER_VERSIONS.includes(version)
+      OSX_AARCH_ONLY_ROUTER_VERSIONS.includes(version)
     );
   }
 

--- a/src/lib/binary.ts
+++ b/src/lib/binary.ts
@@ -6,6 +6,8 @@ import {
 } from "./error";
 import { getFetcher } from "./getFetcher";
 
+const OSX_ONLY_ROUTER_VERSIONS = ["v1.38.0", "v1.39.0"];
+
 export class Binary {
   name: BinaryName;
   repo: Repo;
@@ -44,13 +46,29 @@ export class Binary {
   ): string {
     let targetTriple = enumFromStringValue(TargetTriple, inputTargetTriple);
     if (
-      targetTriple === TargetTriple.AppleArm && this.name === BinaryName.Supergraph
+      targetTriple === TargetTriple.AppleAmd &&
+      this.isAppleArmOnlyRouter(version)
+    ) {
+      throw new MalformedRequestError(
+        `invalid target '${targetTriple}' for '${this.name}' binary, you should download the 'x86_64-apple-darwin' target for router v1.39.1 or later, and it will work on all Mac machines thanks to universal binary.`
+      );
+    }
+    if (
+      targetTriple === TargetTriple.AppleArm &&
+      this.name === BinaryName.Supergraph
     ) {
       throw new MalformedRequestError(
         `invalid target '${targetTriple}' for '${this.name}' binary, you should download the 'x86_64-apple-darwin' target instead and it will work on Mac machines with Apple's ARM processor via emulation.`
       );
     }
     return `${this.name}-${version}-${targetTriple}.tar.gz`;
+  }
+
+  private isAppleArmOnlyRouter(version: string): boolean {
+    return (
+      this.name === BinaryName.Router &&
+      OSX_ONLY_ROUTER_VERSIONS.includes(version)
+    );
   }
 
   getReleaseTarballUrl(inputTargetTriple: string, version: string): string {

--- a/src/lib/binary.ts
+++ b/src/lib/binary.ts
@@ -50,7 +50,7 @@ export class Binary {
       this.isAppleArmOnlyRouter(version)
     ) {
       throw new MalformedRequestError(
-        `invalid target '${targetTriple}' for '${this.name}' binary, you should download the 'x86_64-apple-darwin' target for router v1.39.1 or later, and it will work on all Mac machines thanks to universal binary.`
+        `invalid target '${targetTriple}' for '${this.name}' binary, you should download the 'x86_64-apple-darwin' target for router v1.39.1 or later.`
       );
     }
     if (


### PR DESCRIPTION
Followup to https://github.com/apollographql/rover/pull/1849 this adds checks in orbiter to make sure valid OSX targets are requested. Router 1.38.0 and 1.39.0 are only available for aarch, previous and subsequent versions are available for both aarch and amd64.